### PR TITLE
optimized delay between downloads

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -30,10 +30,10 @@ class CacheHelperTest(unittest.TestCase):
         if os.path.isfile(expected_path):
             os.remove(expected_path)
 
-        # on the first execution the file will be downloaded from the internet
+        # on the first execution the file will be downloaded from the internet, no delay for first download
         time_stamp: float = time.time()
         self.assertEqual(cache.cache_file(test_url), expected_path)
-        self.assertGreaterEqual(time.time() - time_stamp, delay / 1000)
+        self.assertLess(time.time() - time_stamp, delay / 1000)
 
         # on the second execution the file path will be returned
         time_stamp = time.time()

--- a/xbrl/cache.py
+++ b/xbrl/cache.py
@@ -35,7 +35,6 @@ class HttpCache:
         # check if the cache_dir ends with a /
         if not cache_dir.endswith('/'): cache_dir += '/'
         self.cache_dir: str = cache_dir
-        self.delay: int = delay
         self.headers: dict or None = None
         self.connection_manager = ConnectionManager(delay, verify_https=verify_https)
 
@@ -59,10 +58,9 @@ class HttpCache:
             {backoff factor} * (2 ** ({number of total retries} - 1))
         :return:
         """
-        self.connection_manager._delay = delay
+        self.connection_manager._delay_ms = delay
         self.connection_manager._retries = retries
         self.connection_manager._backoff_factor = backoff_factor
-        self.connection_manager._delay = delay
         self.connection_manager.logs = logs
 
     def cache_file(self, file_url: str) -> str:

--- a/xbrl/cache.py
+++ b/xbrl/cache.py
@@ -119,7 +119,7 @@ class HttpCache:
         """
         return self.cache_dir + re.sub("https?://", "", url)
 
-    def cache_edgar_enclosure(self, enclosure_url: str) -> None:
+    def cache_edgar_enclosure(self, enclosure_url: str) -> str:
         """
         The SEC provides zip folders that contain all xbrl related files for a given submission.
         These files are i.e: Instance Document, Extension Taxonomy, Linkbases.
@@ -130,7 +130,7 @@ class HttpCache:
         One way to get the zip enclosure url is through the Structured Disclosure RSS Feeds provided by the SEC:
         https://www.sec.gov/structureddata/rss-feeds-submitted-filings
         :param enclosure_url: url to the zip folder.
-        :return:
+        :return: relative path to extracted zip's content
         """
         if not enclosure_url.endswith('.zip'):
             raise Exception("This is not a valid zip folder")
@@ -141,3 +141,4 @@ class HttpCache:
         with zipfile.ZipFile(enclosure_path, "r") as zip_ref:
             zip_ref.extractall(submission_dir_path)
             zip_ref.close()
+        return submission_dir_path


### PR DESCRIPTION
Delay between 2 downloads still exists.
But only executes if needed.

eg. 

- download file1, 
- do something else for long time, 
- no delay for file2 since delay already elapsed.

Also no delay if only downloading 1file.

Very useful if downloading many fillings.

//find_entry_file might have slipped in, github ui is horrible, might need removing