### PR TITLE
add support for file-like object parsing

### DIFF
--- a/xbrl/helper/xml_parser.py
+++ b/xbrl/helper/xml_parser.py
@@ -4,10 +4,10 @@ namespace map. Element tree discards all prefixes when parsing the file.
 It is used by the different parsing modules.
 """
 import xml.etree.ElementTree as ET
-from io import StringIO
+from io import StringIO, IOBase
 
 
-def parse_file(file: str or StringIO) -> ET.ElementTree:
+def parse_file(file: str or IOBase or StringIO) -> ET.ElementTree:
     """
     Parses a file, returns the Root element with an attribute 'ns_map' containing the prefix - namespaces map
     :param file: either the file path (str) or a file-like object
@@ -17,6 +17,10 @@ def parse_file(file: str or StringIO) -> ET.ElementTree:
 
     root = None
     ns_map = []
+
+    # sets the file pointer back to the beginning in case it was read from multiple times
+    if isinstance(file, IOBase):
+        file.seek(0, 0)
 
     for event, elem in ET.iterparse(file, events):
         if event == "start-ns":

--- a/xbrl/linkbase.py
+++ b/xbrl/linkbase.py
@@ -8,6 +8,7 @@ reference linkbase: ref
 """
 import abc
 import os
+from io import StringIO
 from typing import List
 import xml.etree.ElementTree as ET
 from abc import ABC
@@ -428,7 +429,7 @@ def parse_linkbase_url(linkbase_url: str, linkbase_type: LinkbaseType, cache: Ht
     return parse_linkbase(linkbase_path, linkbase_type, linkbase_url)
 
 
-def parse_linkbase(linkbase_path: str, linkbase_type: LinkbaseType, linkbase_url: str or None = None) -> Linkbase:
+def parse_linkbase(linkbase_path: str or IOBase or StringIO, linkbase_type: LinkbaseType, linkbase_url: str or None = None) -> Linkbase:
     """
     Parses a linkbase and returns a Linkbase object containing all
     locators, arcs and links of the linkbase in a hierarchical order (a Tree)
@@ -440,10 +441,11 @@ def parse_linkbase(linkbase_path: str, linkbase_type: LinkbaseType, linkbase_url
     the url has to be set so that the parser can connect the locator with concept from the taxonomy
     :return:
     """
-    if linkbase_path.startswith('http'): raise XbrlParseException(
-        'This function only parses locally saved linkbases. Please use parse_linkbase_url to parse remote linkbases')
-    if not os.path.exists(linkbase_path):
-        raise LinkbaseNotFoundException(f"Could not find linkbase at {linkbase_path}")
+    if isinstance(linkbase_path, str):
+        if linkbase_path.startswith('http'): raise XbrlParseException(
+            'This function only parses locally saved linkbases. Please use parse_linkbase_url to parse remote linkbases')
+        if not os.path.exists(linkbase_path):
+            raise LinkbaseNotFoundException(f"Could not find linkbase at {linkbase_path}")
 
     root: ET.Element = ET.parse(linkbase_path).getroot()
     # store the role refs in a dictionary, with the role uri as key.
@@ -490,7 +492,8 @@ def parse_linkbase(linkbase_path: str, linkbase_type: LinkbaseType, linkbase_url
             if not locator_href.startswith('http'):
                 # resolve the path
                 # todo, try to get the URL here, instead of the path!!!
-                locator_href = resolve_uri(linkbase_url if linkbase_url else linkbase_path, locator_href)
+                if linkbase_url or isinstance(linkbase_path, str):
+                    locator_href = resolve_uri(linkbase_url if linkbase_url else linkbase_path, locator_href)
             locator_map[loc_label] = Locator(locator_href, loc_label)
 
         # Performance: extract the labels in advance. The label name (xlink:label) is the key and the value is


### PR DESCRIPTION
In my application it doesn't make sense to store the data locally since my disk is ephemeral. Rather, I pull it directly from cloud object storage (s3) and parse the results.

For that reason I wanted to be able to use StringIO to parse the text content directly. The package did not provide any such support.

usage:
```python
from io import StringIO

from xbrl.instance import XbrlParser
from xbrl.cache import HttpCache

PATH =  "/Users/andrewnichol/Downloads/0000320193-18-000145-xbrl/aapl-20180929.xml"

cache: HttpCache = HttpCache("./cache")
cache.set_headers({"From": "webmaster@domain.com", "User-Agent": "domain.com"})
xbrlParser = XbrlParser(cache)

x = open(PATH, "r")
string_file = StringIO(x.read())
inst = xbrlParser.parse_file_obj(string_file)  # could also operate directly on `x` here
```

This had a lot more places to change than I had originally expected, but in the end it works pretty seamlessly.