### PR TITLE
Add schema_root option to parse_ixbrl.

### DIFF
--- a/xbrl/helper/uri_helper.py
+++ b/xbrl/helper/uri_helper.py
@@ -24,7 +24,8 @@ def resolve_uri(dir_uri: str, relative_uri: str) -> str:
     # remove redundant characters in the relative uri
     if relative_uri.startswith('/'): relative_uri = relative_uri[1:]
     if relative_uri.startswith('./'): relative_uri = relative_uri[2:]
-
+    
+    dir_uri = str(dir_uri)
     if not dir_uri.startswith('http'):
         # check if the dir_uri was really a path to a directory or a file
         if '.' in dir_uri.split(os.sep)[-1]:

--- a/xbrl/instance.py
+++ b/xbrl/instance.py
@@ -421,7 +421,7 @@ def parse_ixbrl_url(instance_url: str, cache: HttpCache) -> XbrlInstance:
     return parse_ixbrl(instance_path, cache, instance_url)
 
 
-def parse_ixbrl(instance_path: str, cache: HttpCache, instance_url: str or None = None, encoding=None) -> XbrlInstance:
+def parse_ixbrl(instance_path: str, cache: HttpCache, instance_url: str or None = None, encoding=None, schema_root=None) -> XbrlInstance:
     """
     Parses a inline XBRL (iXBRL) instance file.
 
@@ -458,7 +458,7 @@ def parse_ixbrl(instance_path: str, cache: HttpCache, instance_url: str or None 
         taxonomy: TaxonomySchema = parse_taxonomy_url(schema_url, cache)
     else:
         # try to find the taxonomy extension schema file locally because no full url can be constructed
-        schema_path = resolve_uri(instance_path, schema_uri)
+        schema_path = next(schema_root.glob(f'**/{schema_uri}')) if schema_root else resolve_uri(instance_path, schema_uri)
         taxonomy: TaxonomySchema = parse_taxonomy(schema_path, cache)
 
     # get all contexts and units

--- a/xbrl/instance.py
+++ b/xbrl/instance.py
@@ -458,7 +458,8 @@ def parse_ixbrl(instance_path: str, cache: HttpCache, instance_url: str or None 
         taxonomy: TaxonomySchema = parse_taxonomy_url(schema_url, cache)
     else:
         # try to find the taxonomy extension schema file locally because no full url can be constructed
-        schema_path = next(schema_root.glob(f'**/{schema_uri}')) if schema_root else resolve_uri(instance_path, schema_uri)
+        from pathlib import Path
+        schema_path = next(Path(schema_root).glob(f'**/{schema_uri}')) if schema_root else resolve_uri(instance_path, schema_uri)
         taxonomy: TaxonomySchema = parse_taxonomy(schema_path, cache)
 
     # get all contexts and units

--- a/xbrl/taxonomy.py
+++ b/xbrl/taxonomy.py
@@ -532,6 +532,7 @@ def parse_taxonomy(schema_path: str, cache: HttpCache, schema_url: str or None =
         imported schemas from the remote location. If this url is None, the script will try to find those resources locally.
     :return: parsed :class:`xbrl.taxonomy.TaxonomySchema` object
     """
+    schema_path = str(schema_path)
     if schema_path.startswith('http'): raise XbrlParseException(
         'This function only parses locally saved taxonomies. Please use parse_taxonomy_url to parse remote taxonomy schemas')
     if not os.path.exists(schema_path):


### PR DESCRIPTION
Some organizations(ie. TWSE) provide local ixbrls  which schema path is not relative to instance path, so the parse_ixbrl function can not find the right path for the schema. Add a schema_root option to exactly specify the local scheme directory.