### PR TITLE
Support url-based namespaces

### DIFF
--- a/xbrl/taxonomy.py
+++ b/xbrl/taxonomy.py
@@ -587,6 +587,13 @@ def parse_common_taxonomy(cache: HttpCache, namespace: str) -> TaxonomySchema or
 
     if namespace in ns_schema_map:
         return parse_taxonomy_url(ns_schema_map[namespace], cache)
+
+    # If a namespace appears to be an url, load it as a new taxonomy
+    if is_url(namespace):
+        if not namespace.endswith('.xsd'):
+            namespace += '.xsd'
+        return parse_taxonomy_url(namespace, cache)
+    
     return None
 
 


### PR DESCRIPTION
This feature might contribute to issue #84. 

At least the files provided by the dutch government reference to their XBRL tags with URL based name spaces. 

If a namespace is not special and it is an url, then it would be better to fetch it from the cache. 