### PR TITLE
Fix period string representation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -127,7 +127,7 @@ Here is an example of what the json representation will look like:
           "dimensions": {
             "concept": "RevenueFromContractWithCustomerTextBlock",
             "entity": "0000320193",
-            "period": "2021-09-26/2022-03-26"
+            "period": "2021-09-26T00:00:00/2022-03-26T00:00:00"
           }
         }
       }

--- a/xbrl/instance.py
+++ b/xbrl/instance.py
@@ -241,9 +241,12 @@ class AbstractFact(abc.ABC):
 
     def json(self, **kwargs) -> dict:
         if isinstance(self.context, TimeFrameContext):
-            period: str = f"{self.context.start_date}/{self.context.end_date}"
+            start_date = self.context.start_date.strftime('%Y-%m-%dT%H:%M:%S')
+            end_date = self.context.end_date.strftime('%Y-%m-%dT%H:%M:%S')
+            period: str = f"{start_date}/{end_date}"
         elif isinstance(self.context, InstantContext):
-            period: str = str(self.context.instant_date)
+            instant_date = self.context.instant_date.strftime('%Y-%m-%dT%H:%M:%S')
+            period: str = str(instant_date)
         else:
             period: str = ''  # Forever context not specified in REC-2021-10-13
 


### PR DESCRIPTION
Hey @manusimidt, I was looking at the [XBRL-JSON spec](https://www.xbrl.org/Specification/xbrl-json/CR-2021-07-07/xbrl-json-CR-2021-07-07.html#sec-dimensions) and noticed:

> ### period (string)
>
> A valid [period string representation](https://www.xbrl.org/Specification/oim-common/CR-2021-07-07/oim-common-CR-2021-07-07.html#term-period-string-representation) for the `{interval}` property of the _period core dimension_, if present. See [**Example 2**](https://www.xbrl.org/Specification/xbrl-json/CR-2021-07-07/xbrl-json-CR-2021-07-07.html#example-period-duration) and [**Example 3**](https://www.xbrl.org/Specification/xbrl-json/CR-2021-07-07/xbrl-json-CR-2021-07-07.html#example-period-instant).

The [period string representation casts dates to datetimes](https://www.xbrl.org/Specification/oim-common/CR-2021-07-07/oim-common-CR-2021-07-07.html#term-period-string-representation) when output in the JSON. It says:

> It should be noted that unlike the xbrli:dateUnion type used in xBRL-XML, the xs:dateTime datatype used here does not allow the time component to be omitted.


I've made a small change here to output the times alongside dates. Thanks!