### PR TITLE
Fix concept type (#153)

### DIFF
--- a/xbrl/taxonomy.py
+++ b/xbrl/taxonomy.py
@@ -698,7 +698,7 @@ def parse_taxonomy(schema_path: str, cache: HttpCache, imported_schema_uris : se
         el_name: str = element.attrib['name']
 
         concept = Concept(el_id, schema_url, el_name)
-        concept.type = element.attrib['type'] if 'type' in element.attrib else False
+        concept.concept_type = element.attrib['type'] if 'type' in element.attrib else None
         concept.nillable = bool(element.attrib['nillable']) if 'nillable' in element.attrib else False
         concept.abstract = bool(element.attrib['abstract']) if 'abstract' in element.attrib else False
         type_attr_name = XBRLI_NS + 'periodType'


### PR DESCRIPTION
As in #153, there's a small attribute mismatch.

https://github.com/manusimidt/py-xbrl/blob/16c555c03721477e8e463a7e949e369d772ca304/xbrl/taxonomy.py#L477

https://github.com/manusimidt/py-xbrl/blob/16c555c03721477e8e463a7e949e369d772ca304/xbrl/taxonomy.py#L676-L677

I have changed `concept.type` to `concept.concept_type`, and also set its default to `None`.